### PR TITLE
chore(app): Remove Express x-powered-by header

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -43,6 +43,7 @@
     "url": "git+https://github.com/mozilla/page-metadata-service.git"
   },
   "scripts": {
+    "start": "node service",
     "test": "npm-run-all test:*",
     "test:lint": "eslint .",
     "test:mocha": "istanbul cover _mocha --report lcovonly -- test/*.js -R spec"

--- a/app/service.js
+++ b/app/service.js
@@ -75,6 +75,7 @@ function getUrlMetadata(url) {
 
 const app = express();
 app.use(bodyParser.json()); // for parsing application/json
+app.disable('x-powered-by');
 
 app.post('/v1/metadata', function(req, res) {
   const responseData = {


### PR DESCRIPTION
Removes the unnecessary `X-Powered-By` Express header, because advertising.

