### PR TITLE
Allow for optional charset in content-type header

### DIFF
--- a/app/service.js
+++ b/app/service.js
@@ -87,7 +87,8 @@ app.post('/v1/metadata', function(req, res) {
     res.status(status).json(responseData);
   };
 
-  if (req.headers['content-type'] !== 'application/json') {
+  // #45: Server fails if you try passing charset in Content-Type
+  if (!(/^application\/json/).test(req.headers['content-type'])) {
     fail(errorMessages.headerRequired, 415);
     return;
   }


### PR DESCRIPTION
Now with `Content-Type: application/json; charset=utf-8` support!

```sh
$ http POST http://localhost:7001/v1/metadata urls:='["https://bing.com"]' --json

HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 436
Content-Type: application/json; charset=utf-8
Date: Thu, 11 Aug 2016 02:49:29 GMT
ETag: W/"1b4-DvvSqpJmsS3xmDhR9F8sNQ"
X-Powered-By: Express

{
    "error": "",
    "urls": {
        "https://bing.com": {
            "description": "Bing helps you turn information into action, making it faster and easier to go from searching to doing.",
            "favicon_url": "https://bing.com/fd/s/a/hp/bing.svg",
            "images": [
                {
                    "entropy": 1,
                    "height": 500,
                    "url": "data://undefinedimage/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAEALAAAAAABAAEAAAIBTAA7",
                    "width": 500
                }
            ],
            "original_url": "https://bing.com",
            "title": "Bing",
            "url": "https://bing.com"
        }
    }
}
```

Fixes #45 

