### PR TITLE
Make sure req.body.urls is Array-like

### DIFF
--- a/app/service.js
+++ b/app/service.js
@@ -92,7 +92,7 @@ app.post('/v1/metadata', function(req, res) {
     return;
   }
 
-  if (!req.body.urls || req.body.urls.length <= 0) {
+  if (!req.body.urls || !Array.isArray(req.body.urls) || req.body.urls.length <= 0) {
     fail(errorMessages.urlsRequired, 400);
     return;
   }


### PR DESCRIPTION
### Before:

```sh
http POST 'http://localhost:7001/v1/metadata' urls='lol, im a string' Content-Type:application/json --verbose

POST /v1/metadata HTTP/1.1
Accept: application/json
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Length: 28
Content-Type: application/json
Host: localhost:7001
User-Agent: HTTPie/0.9.1

{
    "urls": "lol, im a string"
}

HTTP/1.1 500 Internal Server Error
Connection: keep-alive
Content-Length: 1421
Content-Type: text/html; charset=utf-8
Date: Thu, 11 Aug 2016 06:14:52 GMT
X-Content-Type-Options: nosniff
X-Powered-By: Express

TypeError: req.body.urls.map is not a function<br> &nbsp; &nbsp;at /Users/pdehaan/dev/github/mozilla/page-metadata-service/app/service.js:100:34<br> &nbsp; &nbsp;at Layer.handle [as handle_request] (/Users/pdehaan/dev/github/mozilla/page-metadata-service/app/node_modules/express/lib/router/layer.js:95:5)<br> &nbsp; &nbsp;at next (/Users/pdehaan/dev/github/mozilla/page-metadata-service/app/node_modules/express/lib/router/route.js:131:13)<br> &nbsp; &nbsp;at Route.dispatch (/Users/pdehaan/dev/github/mozilla/page-metadata-service/app/node_modules/express/lib/router/route.js:112:3)<br> &nbsp; &nbsp;at Layer.handle [as handle_request] (/Users/pdehaan/dev/github/mozilla/page-metadata-service/app/node_modules/express/lib/router/layer.js:95:5)<br> &nbsp; &nbsp;at /Users/pdehaan/dev/github/mozilla/page-metadata-service/app/node_modules/express/lib/router/index.js:277:22<br> &nbsp; &nbsp;at Function.process_params (/Users/pdehaan/dev/github/mozilla/page-metadata-service/app/node_modules/express/lib/router/index.js:330:12)<br> &nbsp; &nbsp;at next (/Users/pdehaan/dev/github/mozilla/page-metadata-service/app/node_modules/express/lib/router/index.js:271:10)<br> &nbsp; &nbsp;at /Users/pdehaan/dev/github/mozilla/page-metadata-service/app/node_modules/body-parser/lib/read.js:129:5<br> &nbsp; &nbsp;at invokeCallback (/Users/pdehaan/dev/github/mozilla/page-metadata-service/app/node_modules/raw-body/index.js:262:16)
```

### After:

```sh
http POST 'http://localhost:7001/v1/metadata' urls='lol, im a string' Content-Type:application/json --verbose

POST /v1/metadata HTTP/1.1
Accept: application/json
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Length: 28
Content-Type: application/json
Host: localhost:7001
User-Agent: HTTPie/0.9.1

{
    "urls": "lol, im a string"
}

HTTP/1.1 400 Bad Request
Connection: keep-alive
Content-Length: 117
Content-Type: application/json; charset=utf-8
Date: Thu, 11 Aug 2016 03:10:38 GMT
ETag: W/"75-Mr+uqLDKU6KvWEox4m7Ydg"
X-Powered-By: Express

{
    "error": "The post body must be a JSON payload in the following format: {urls: [\"http://example.com\"]}.",
    "urls": []
}
```

Fixes #44 