### PR TITLE
Remove console logs during npm test

### DIFF
--- a/app/service.js
+++ b/app/service.js
@@ -49,7 +49,9 @@ function getDocumentMetadata(url, window) {
     }]
   };
 
-  console.log(`Generated Metadata for ${url}:\n${JSON.stringify(responseData)}`); // eslint-disable-line no-console
+  if (!process.env.CI) {
+    console.log(`Generated Metadata for ${url}:\n${JSON.stringify(responseData)}`); // eslint-disable-line no-console
+  }
 
   return responseData;
 }


### PR DESCRIPTION
This will still show the `console.log()` statements locally, but disable them on Travis-CI.