### PR TITLE
Remove fastimage ignore from .nsprc

### DIFF
--- a/app/.nsprc
+++ b/app/.nsprc
@@ -1,5 +1,4 @@
 {
   "exceptions": [
-    "https://nodesecurity.io/advisories/130"
   ]
 }

--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,7 @@
     "body-parser": "^1.15.2",
     "domino": "^1.0.25",
     "express": "^4.14.0",
-    "fastimage": "^2.0.0",
+    "fastimage": "^2.0.1",
     "isomorphic-fetch": "^2.2.1",
     "node-statsd": "^0.1.1",
     "page-metadata-parser": "^0.5.1",


### PR DESCRIPTION
This was fixed upstream in https://github.com/ShogunPanda/fastimage/pull/5
